### PR TITLE
add Canton to Games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add a migration update to fillup Website field on Games
 - add facets extra data for platform name, location name & genre name - Games-of-Switzerland/swissgamesgarden#50
+- add support of Games canton(s) - Games-of-Switzerland/swissgamesgarden#51
 
 ## [0.1.0] - 2022-03-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 #  🎮👾 Swiss Games Garden
 
-Swiss Games Garden API project is based on 💦 [Drupal](https://drupal.org/), 🕸 [Json:API](https://jsonapi.org/) and 🥃 [Gin](https://github.com/EasyCorp/EasyAdminBundle) as Admin UI.   
-We built it around 🔍 [Elasticsearch](https://www.elastic.co/) to expose Search Engine capabilities.   
-It uses 🐳 [Docker](http://docker.com/) for running.   
-We use 📝 [Swagger](https://swagger.io/) for documentation and ✅ [PHPUnit](https://phpunit.de/)/[Behat](https://docs.behat.org) for testing.   
+Swiss Games Garden API project is based on 💦 [Drupal](https://drupal.org/), 🕸 [Json:API](https://jsonapi.org/) and 🥃 [Gin](https://github.com/EasyCorp/EasyAdminBundle) as Admin UI.
+We built it around 🔍 [Elasticsearch](https://www.elastic.co/) to expose Search Engine capabilities.
+It uses 🐳 [Docker](http://docker.com/) for running.
+We use 📝 [Swagger](https://swagger.io/) for documentation and ✅ [PHPUnit](https://phpunit.de/)/[Behat](https://docs.behat.org) for testing.
 We deploy with 🚀 [Capistrano](https://github.com/capistrano/capistrano) and mange our dependencies with 🎶 [Composer](https://getcomposer.org/) & 🏜 [Phive](https://phar.io/).
 
 We made it with 💗.
@@ -322,74 +322,6 @@ Check that Elasticsearch is up and running.
 docker-compose exec elasticsearch curl http://127.0.0.1:9200/_cat/health
 ```
 
-### List all games
-
-```bash
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_game/_search?pretty"
-```
-
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_game/_search?pretty&explain" -H 'Content-Type: application/json' -d'
-{
-    "query" : {
-        "match_phrase" : {
-            "releases.platform": {
-                "query": "ps4",
-                "analyzer": "search_synonyms"
-            }
-        }
-    }
-}
-'
-
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_game/_search?pretty&explain" -H 'Content-Type: application/json' -d'
-{
-    "query" : {
-        "nested": {
-            "path" : "releases",
-            "query": {
-              "query_string": {
-                "default_field": "releases.platform",
-                "query": "ps4"
-              }
-            }
-        }
-    }
-}
-'
-
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_game/_search?pretty&explain" -H 'Content-Type: application/json' -d'
-{
-    "query" : {
-      "query_string": {
-        "default_field": "title",
-        "query": "kill"
-      }
-    }
-}
-'
-
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_game/_search?pretty&explain" -H 'Content-Type: application/json' -d'
-{
-    "query" : {
-      "query_string": {
-        "default_field": "desc",
-        "query": "memories"
-      }
-    }
-}
-'
-
-docker-compose exec elasticsearch curl -X GET "http://127.0.0.1:9200/gos_node_studio/_search?pretty&explain" -H 'Content-Type: application/json' -d'
-{
-    "query" : {
-      "query_string": {
-        "default_field": "name",
-        "query": "softvar"
-      }
-    }
-}
-'
-
 ## 📋 Documentations
 
 We use *Swagger* to document our custom REST endpoints.
@@ -444,6 +376,24 @@ If you get something else in `host` (such as `localhost`), then your initial boo
 
 ```
 docker-compose exec app docker-as-drupal db-reset --update-dump --with-default-content
+```
+
+### Elasticsearch indexing failed with error `FORBIDDEN/12/index read-only / allow delete` ?
+
+By default, Elasticsearch installed goes into `read-only mode when you have less than 5% of free disk space.
+
+First, you will need to remove all documents and indices from Elasticsearch (or change the disk size).
+
+```bash
+docker-compose exec elasticsearch curl -X DELETE http://127.0.0.1:9200/_all
+```
+
+Then you can fix it by running the following commands:
+
+```bash
+docker-compose exec elasticsearch curl -XPUT -H "Content-Type: application/json" http://127.0.0.1:9200/_cluster/settings -d '{ "transient": { "cluster.routing.allocation.disk.threshold_enabled": false } }'
+docker-compose exec elasticsearch curl -XPUT -H "Content-Type: application/json" http://127.0.0.1:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
+docker-compose exec elasticsearch curl -XPUT -H "Content-Type: application/json" http://127.0.0.1:9200/_cluster/settings -d '{ "transient": { "cluster.routing.allocation.disk.threshold_enabled": false } }'
 ```
 
 ### Error while importing config ?

--- a/behat/Features/elasticsearch/search.games.cantons.facets.feature
+++ b/behat/Features/elasticsearch/search.games.cantons.facets.feature
@@ -1,0 +1,43 @@
+@elasticsearch
+  Feature: Retrieve Games Cantons facets from Elasticsearch
+  In order to filter the Games Search API
+  As a client software developer
+  I need to be able to fetch faceted Cantons in a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: The Cantons facets/aggregations should follow a strict given structure.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.cantons.facets.json"
+
+  Scenario Outline: The Cantons facets/aggregations should use the same filter as the global query - without itself as filter.
+    Given I send a "GET" request to <url>
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets" should have 2 elements
+    And the JSON nodes should be equal to:
+      | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].key | geneva |
+      | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].doc_count | 2 |
+      | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].key | vaud |
+      | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].doc_count | 1 |
+    Examples:
+      | url |
+      | "http://api.gos.test/search/games?page=0" |
+      | "http://api.gos.test/search/games?page=0&cantons[]=geneva" |
+
+    Scenario: The Cantons facets/aggregations should be affected by filtered Stores and/or Platforms.
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
+    And the JSON node "aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].key | geneva |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].doc_count | 1 |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].key | vaud |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].doc_count | 1 |
+
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
+    And the JSON node "aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].key | geneva |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[0].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].key | vaud |
+        | aggregations.aggs_all.all_filtered_cantons.all_nested_cantons.cantons_name_keyword.buckets[1].doc_count | 0 |

--- a/behat/Features/elasticsearch/search.games.cantons.feature
+++ b/behat/Features/elasticsearch/search.games.cantons.feature
@@ -1,0 +1,32 @@
+@elasticsearch
+  Feature: Retrieve Games items from Elasticsearch
+  In order to use a Games Search API
+  As a client software developer
+  I need to be able to filter by cantons a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: Games Resource should respond with filtered games when a valid canton slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&cantons[]=vaud"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | f990d6af-d50d-4b35-a79a-72a1e12a7422 |
+
+    Scenario: Games Resource should respond with filtered games when multiple valid cantons slugs are given.
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&cantons[]=geneva&cantons[]=vaud"
+      Then the response status code should be 200
+      And the response should be in JSON
+      And the JSON node "hits.hits" should have 2 elements
+      And the JSON node "hits.hits[0]._source" should exist
+      And the JSON node "hits.hits[1]._source" should exist
+      And the JSON nodes should be equal to:
+        | hits.hits[0]._source.uuid | 9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd |
+        | hits.hits[1]._source.uuid | f990d6af-d50d-4b35-a79a-72a1e12a7422 |
+
+  Scenario: Games Resource should respond with an error when a non-valid canton slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&cantons[]=test"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "errors.cantons" should exist
+    And the JSON node "errors.cantons" should have 1 element
+    And the JSON node "errors.cantons[0]" should be equal to "At least one given Canton(s) has not been found."

--- a/behat/Features/elasticsearch/search.games.locations.facets.feature
+++ b/behat/Features/elasticsearch/search.games.locations.facets.feature
@@ -1,5 +1,5 @@
 @elasticsearch
-  Feature: Retrieve Games Locations facets from Elasticsearch
+Feature: Retrieve Games Locations facets from Elasticsearch
   In order to filter the Games Search API
   As a client software developer
   I need to be able to fetch faceted Locations in a JSON encoded resources from Elasticsearch via a Proxy
@@ -14,14 +14,16 @@
     Given I send a "GET" request to <url>
     Then the response status code should be 200
     And the response should be in JSON
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 4 elements
     And the JSON nodes should be equal to:
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | zurich |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | lausanne |
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | geneva |
-      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | zurich |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 1 |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].key | geneva |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].doc_count | 0 |
     Examples:
       | url |
       | "http://api.gos.test/search/games?page=0" |
@@ -29,17 +31,19 @@
 
     Scenario: The Locations facets/aggregations should be affected by filtered Stores and/or Platforms.
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
+      And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
-        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
-        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | geneva |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | lausanne |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | fribourg |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | geneva |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].doc_count | 0 |
 
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | zurich |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
@@ -47,3 +51,5 @@
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | geneva |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].key | lausanne |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[3].doc_count | 0 |

--- a/behat/Features/jsonapi/canton.feature
+++ b/behat/Features/jsonapi/canton.feature
@@ -1,0 +1,30 @@
+Feature: Location
+
+  Scenario: Fetching a canton with a wrong UUID should return a 404.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton/abcdef"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetching a canton by his UUID works, fetching it by his NID does not works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton/37"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetch a canton using UUID should return it in the default language
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON node "data.attributes.langcode" should be equal to "en"
+    And the JSON node "data.attributes.name" should be equal to "Vaud"
+    And the JSON node "data.attributes.slug" should be equal to "vaud"
+
+  Scenario: Fetching canton using the slug filter may return one or more results.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton?filter[slug]=vaud"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.langcode" should be equal to "en"
+    And the JSON node "data[0].attributes.name" should be equal to "Vaud"
+    And the JSON node "data[0].attributes.slug" should be equal to "vaud"

--- a/behat/Features/jsonapi/cantons.feature
+++ b/behat/Features/jsonapi/cantons.feature
@@ -1,0 +1,16 @@
+Feature: Cantons
+
+  Scenario: The list of canton return only published ones.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should have 2 elements
+    And the JSON node "data[0].attributes.name" should be equal to "Vaud"
+    And the JSON node "data[1].attributes.name" should be equal to "Geneva"
+
+  Scenario: Sorting of canton listing works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/canton?sort=name"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.name" should be equal to "Geneva"
+    And the JSON node "data[1].attributes.name" should be equal to "Vaud"

--- a/behat/Features/jsonapi/locations.feature
+++ b/behat/Features/jsonapi/locations.feature
@@ -4,10 +4,11 @@ Feature: Locations
     Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location"
     Then the response status code should be 200
     And the response should be in JSON
-    And the JSON node "data" should have 3 elements
+    And the JSON node "data" should have 4 elements
     And the JSON node "data[0].attributes.name" should be equal to "Geneva"
     And the JSON node "data[1].attributes.name" should be equal to "Zürich"
     And the JSON node "data[2].attributes.name" should be equal to "Fribourg"
+    And the JSON node "data[3].attributes.name" should be equal to "Lausanne"
 
   Scenario: Sorting of location listing works.
     Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location?sort=name"
@@ -15,4 +16,5 @@ Feature: Locations
     And the response should be in JSON
     And the JSON node "data[0].attributes.name" should be equal to "Fribourg"
     And the JSON node "data[1].attributes.name" should be equal to "Geneva"
-    And the JSON node "data[2].attributes.name" should be equal to "Zürich"
+    And the JSON node "data[2].attributes.name" should be equal to "Lausanne"
+    And the JSON node "data[3].attributes.name" should be equal to "Zürich"

--- a/behat/Features/redirects/canton.feature
+++ b/behat/Features/redirects/canton.feature
@@ -1,0 +1,8 @@
+Feature: Canton term redirection
+
+  @redirect_disable
+  Scenario: Accessing a taxonomy-term Canton page should be forbidden by redirection to frontpage.
+    Given I am on "/taxonomy/term/37"
+    Then the response status code should be 301
+    Then I should be redirected to "/"
+

--- a/behat/Fixtures/elasticsearch/schemaref.search.games.cantons.facets.json
+++ b/behat/Fixtures/elasticsearch/schemaref.search.games.cantons.facets.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "title": "The root schema",
+  "required": [
+    "aggregations"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "aggregations": {
+      "$id": "#/properties/aggregations",
+      "type": "object",
+      "title": "The aggregations schema",
+      "required": [
+        "aggs_all"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "aggs_all": {
+          "$id": "#/properties/aggregations/properties/aggs_all",
+          "type": "object",
+          "title": "The aggs_all schema",
+          "required": [
+            "all_filtered_locations"
+          ],
+          "additionalProperties": true,
+          "properties": {
+            "all_filtered_locations": {
+              "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations",
+              "type": "object",
+              "title": "The all_filtered_locations schema",
+              "examples": [
+                {
+                  "doc_count": 2,
+                  "all_nested_locations": {
+                    "doc_count": 1,
+                    "locations_name_keyword": {
+                      "doc_count_error_upper_bound": 0,
+                      "sum_other_doc_count": 0,
+                      "buckets": [
+                        {
+                          "key": "zurich",
+                          "doc_count": 1
+                        },
+                        {
+                          "key": "fribourg",
+                          "doc_count": 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "doc_count",
+                "all_nested_locations"
+              ],
+              "additionalProperties": true,
+              "properties": {
+                "doc_count": {
+                  "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/doc_count",
+                  "type": "integer",
+                  "title": "The doc_count schema",
+                  "default": 0,
+                  "examples": [
+                    2
+                  ]
+                },
+                "all_nested_locations": {
+                  "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations",
+                  "type": "object",
+                  "title": "The all_nested_locations schema",
+                  "examples": [
+                    {
+                      "doc_count": 1,
+                      "locations_name_keyword": {
+                        "doc_count_error_upper_bound": 0,
+                        "sum_other_doc_count": 0,
+                        "buckets": [
+                          {
+                            "key": "zurich",
+                            "doc_count": 1
+                          },
+                          {
+                            "key": "fribourg",
+                            "doc_count": 0
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "required": [
+                    "doc_count",
+                    "locations_name_keyword"
+                  ],
+                  "additionalProperties": true,
+                  "properties": {
+                    "doc_count": {
+                      "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/doc_count",
+                      "type": "integer",
+                      "title": "The doc_count schema",
+                      "default": 0,
+                      "examples": [
+                        1
+                      ]
+                    },
+                    "locations_name_keyword": {
+                      "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword",
+                      "type": "object",
+                      "title": "The locations_name_keyword schema",
+                      "examples": [
+                        {
+                          "doc_count_error_upper_bound": 0,
+                          "sum_other_doc_count": 0,
+                          "buckets": [
+                            {
+                              "key": "zurich",
+                              "doc_count": 1
+                            },
+                            {
+                              "key": "fribourg",
+                              "doc_count": 0
+                            },
+                            {
+                              "key": "Platformer",
+                              "doc_count": 0
+                            },
+                            {
+                              "key": "Puzzle",
+                              "doc_count": 0
+                            }
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "doc_count_error_upper_bound",
+                        "sum_other_doc_count",
+                        "buckets"
+                      ],
+                      "additionalProperties": true,
+                      "properties": {
+                        "doc_count_error_upper_bound": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/doc_count_error_upper_bound",
+                          "type": "integer",
+                          "title": "The doc_count_error_upper_bound schema",
+                          "default": 0,
+                          "examples": [
+                            0
+                          ]
+                        },
+                        "sum_other_doc_count": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/sum_other_doc_count",
+                          "type": "integer",
+                          "title": "The sum_other_doc_count schema",
+                          "default": 0,
+                          "examples": [
+                            0
+                          ]
+                        },
+                        "buckets": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets",
+                          "type": "array",
+                          "title": "The buckets schema",
+                          "default": [],
+                          "examples": [
+                            [
+                              {
+                                "key": "zurich",
+                                "doc_count": 1
+                              },
+                              {
+                                "key": "fribourg",
+                                "doc_count": 0
+                              }
+                            ]
+                          ],
+                          "additionalItems": true,
+                          "items": {
+                            "anyOf": [
+                              {
+                                "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0",
+                                "type": "object",
+                                "title": "The first anyOf schema",
+                                "examples": [
+                                  {
+                                    "key": "zurich",
+                                    "doc_count": 1
+                                  }
+                                ],
+                                "required": [
+                                  "key",
+                                  "doc_count"
+                                ],
+                                "additionalProperties": true,
+                                "properties": {
+                                  "key": {
+                                    "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0/properties/key",
+                                    "type": "string",
+                                    "title": "The key schema",
+                                    "default": "",
+                                    "examples": [
+                                      "zurich"
+                                    ]
+                                  },
+                                  "doc_count": {
+                                    "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0/properties/doc_count",
+                                    "type": "integer",
+                                    "title": "The doc_count schema",
+                                    "default": 0,
+                                    "examples": [
+                                      1
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/d8/sync/core.entity_form_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_form_display.node.game.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.game.body
     - field.field.node.game.field_article_links
     - field.field.node.game.field_awards
+    - field.field.node.game.field_cantons
     - field.field.node.game.field_completeness
     - field.field.node.game.field_contextual_links
     - field.field.node.game.field_credits
@@ -109,6 +110,7 @@ third_party_settings:
         - field_player
         - field_stores
         - field_locations
+        - field_cantons
         - field_languages
         - field_genres
         - field_sponsors
@@ -169,21 +171,31 @@ content:
     third_party_settings: {  }
   field_awards:
     type: string_textfield
-    weight: 130
+    weight: 131
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_cantons:
+    type: entity_reference_autocomplete
+    weight: 24
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_contextual_links:
     type: contextual_link_default
-    weight: 132
+    weight: 133
     region: content
     settings: {  }
     third_party_settings: {  }
   field_credits:
     type: text_textarea
-    weight: 133
+    weight: 134
     region: content
     settings:
       rows: 5
@@ -191,7 +203,7 @@ content:
     third_party_settings: {  }
   field_genres:
     type: entity_reference_autocomplete
-    weight: 25
+    weight: 26
     region: content
     settings:
       match_operator: CONTAINS
@@ -211,7 +223,7 @@ content:
     third_party_settings: {  }
   field_languages:
     type: entity_reference_autocomplete
-    weight: 24
+    weight: 25
     region: content
     settings:
       match_operator: CONTAINS
@@ -245,6 +257,7 @@ content:
     region: content
     settings:
       sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_player:
     type: player_default
@@ -274,7 +287,7 @@ content:
     third_party_settings: {  }
   field_social_networks:
     type: social_default
-    weight: 131
+    weight: 132
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -288,7 +301,7 @@ content:
     third_party_settings: {  }
   field_sponsors:
     type: entity_reference_autocomplete
-    weight: 26
+    weight: 27
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.canton.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.canton.default.yml
@@ -1,0 +1,53 @@
+uuid: c015ab75-0fc8-4258-8d54-2f348a4bd39d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.canton.field_path
+    - field.field.taxonomy_term.canton.field_slug
+    - taxonomy.vocabulary.canton
+  module:
+    - fieldable_path
+    - path
+id: taxonomy_term.canton.default
+targetEntityType: taxonomy_term
+bundle: canton
+mode: default
+content:
+  field_path:
+    type: fieldable_path_widget
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_slug:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/d8/sync/core.entity_view_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.game.body
     - field.field.node.game.field_article_links
     - field.field.node.game.field_awards
+    - field.field.node.game.field_cantons
     - field.field.node.game.field_completeness
     - field.field.node.game.field_contextual_links
     - field.field.node.game.field_credits
@@ -68,6 +69,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 14
+    region: content
+  field_cantons:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 23
     region: content
   field_contextual_links:
     type: contextual_link_default

--- a/config/d8/sync/core.entity_view_display.node.game.teaser.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.game.body
     - field.field.node.game.field_article_links
     - field.field.node.game.field_awards
+    - field.field.node.game.field_cantons
     - field.field.node.game.field_completeness
     - field.field.node.game.field_contextual_links
     - field.field.node.game.field_credits
@@ -54,6 +55,7 @@ content:
 hidden:
   field_article_links: true
   field_awards: true
+  field_cantons: true
   field_completeness: true
   field_contextual_links: true
   field_credits: true

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.canton.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.canton.default.yml
@@ -1,0 +1,39 @@
+uuid: 9a248535-baa9-4640-a025-e694983ead63
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.canton.field_path
+    - field.field.taxonomy_term.canton.field_slug
+    - taxonomy.vocabulary.canton
+  module:
+    - fieldable_path
+    - text
+id: taxonomy_term.canton.default
+targetEntityType: taxonomy_term
+bundle: canton
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_path:
+    type: fieldable_path_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_slug:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/d8/sync/core.extension.yml
+++ b/config/d8/sync/core.extension.yml
@@ -42,6 +42,7 @@ module:
   gos_game: 0
   gos_rest: 0
   gos_site: 0
+  hal: 0
   help: 0
   history: 0
   image: 0

--- a/config/d8/sync/field.field.node.game.field_cantons.yml
+++ b/config/d8/sync/field.field.node.game.field_cantons.yml
@@ -1,0 +1,29 @@
+uuid: 106e29ae-e772-48f2-9ac3-53eacb53f45c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cantons
+    - node.type.game
+    - taxonomy.vocabulary.canton
+id: node.game.field_cantons
+field_name: field_cantons
+entity_type: node
+bundle: game
+label: Canton(s)
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      canton: canton
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/d8/sync/field.field.taxonomy_term.canton.field_path.yml
+++ b/config/d8/sync/field.field.taxonomy_term.canton.field_path.yml
@@ -1,0 +1,23 @@
+uuid: 25986128-36ea-41d8-8063-f6cd3235e3ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_path
+    - taxonomy.vocabulary.canton
+  module:
+    - fieldable_path
+id: taxonomy_term.canton.field_path
+field_name: field_path
+entity_type: taxonomy_term
+bundle: canton
+label: Path
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: fieldable_path

--- a/config/d8/sync/field.field.taxonomy_term.canton.field_slug.yml
+++ b/config/d8/sync/field.field.taxonomy_term.canton.field_slug.yml
@@ -1,0 +1,19 @@
+uuid: 8ebab049-33f3-49eb-988f-9840e1b8bb77
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_slug
+    - taxonomy.vocabulary.canton
+id: taxonomy_term.canton.field_slug
+field_name: field_slug
+entity_type: taxonomy_term
+bundle: canton
+label: Slug
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/d8/sync/field.storage.node.field_cantons.yml
+++ b/config/d8/sync/field.storage.node.field_cantons.yml
@@ -1,0 +1,20 @@
+uuid: be172155-e906-416c-af96-ee2ddc8af6d9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_cantons
+field_name: field_cantons
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/hal.settings.yml
+++ b/config/d8/sync/hal.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: YD6v6hkrHtj51mcZHn6s2HulUJHWVZ_D7Y_SllXF6WE
+link_domain: null

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--canton.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--canton.yml
@@ -1,0 +1,149 @@
+uuid: 40fec889-f07b-4a69-9810-59fabd96075d
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.canton
+id: taxonomy_term--canton
+disabled: false
+path: taxonomy_term/canton
+resourceType: taxonomy_term--canton
+resourceFields:
+  tid:
+    disabled: false
+    fieldName: tid
+    publicName: tid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  revision_id:
+    disabled: true
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  revision_created:
+    disabled: true
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: true
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: true
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: true
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  name:
+    disabled: false
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+  description:
+    disabled: true
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+  weight:
+    disabled: false
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+  parent:
+    disabled: true
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  releases_normalized:
+    disabled: false
+    fieldName: releases_normalized
+    publicName: releases_normalized
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  metatag_normalized:
+    disabled: false
+    fieldName: metatag_normalized
+    publicName: metatag_normalized
+    enhancer:
+      id: ''
+  path:
+    disabled: true
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  field_path:
+    disabled: true
+    fieldName: field_path
+    publicName: field_path
+    enhancer:
+      id: ''
+  field_slug:
+    disabled: false
+    fieldName: field_slug
+    publicName: slug
+    enhancer:
+      id: ''

--- a/config/d8/sync/taxonomy.vocabulary.canton.yml
+++ b/config/d8/sync/taxonomy.vocabulary.canton.yml
@@ -1,0 +1,8 @@
+uuid: 4e521e5b-04dc-4752-b0e0-f8e8d4294fc8
+langcode: en
+status: true
+dependencies: {  }
+name: Canton
+vid: canton
+description: ''
+weight: 0

--- a/web/modules/custom/gos_default_content/content/node/9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd.json
+++ b/web/modules/custom/gos_default_content/content/node/9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd.json
@@ -17,6 +17,11 @@
                 "lang": "en"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_cantons": [
+            {
+                "href": "http:\/\/default\/taxonomy\/term\/38?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_genres": [
             {
                 "href": "http:\/\/default\/taxonomy\/term\/20?_format=hal_json"
@@ -115,6 +120,23 @@
                     }
                 ],
                 "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_cantons": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/taxonomy\/term\/38?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/canton"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "7fd1c607-99c3-415c-92fc-b3033b2a7b90"
+                    }
+                ]
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_genres": [

--- a/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
+++ b/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
@@ -20,6 +20,9 @@
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_cantons": [
             {
                 "href": "http:\/\/default\/taxonomy\/term\/37?_format=hal_json"
+            },
+            {
+                "href": "http:\/\/default\/taxonomy\/term\/38?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_genres": [
@@ -124,6 +127,21 @@
                 "uuid": [
                     {
                         "value": "7eb54de6-4f2c-471e-b84b-ac7a9c8ff729"
+                    }
+                ]
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/taxonomy\/term\/38?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/canton"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "7fd1c607-99c3-415c-92fc-b3033b2a7b90"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
+++ b/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
@@ -17,9 +17,19 @@
                 "lang": "en"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_cantons": [
+            {
+                "href": "http:\/\/default\/taxonomy\/term\/37?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_genres": [
             {
                 "href": "http:\/\/default\/taxonomy\/term\/22?_format=hal_json"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "href": "http:\/\/default\/locations\/lausanne?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_releases": [
@@ -101,6 +111,23 @@
                 "lang": "en"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_cantons": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/taxonomy\/term\/37?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/canton"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "7eb54de6-4f2c-471e-b84b-ac7a9c8ff729"
+                    }
+                ]
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_genres": [
             {
                 "_links": {
@@ -114,6 +141,23 @@
                 "uuid": [
                     {
                         "value": "55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/locations\/lausanne?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "b3165598-63fe-4717-a30e-11daf4389257"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729.json
@@ -1,0 +1,111 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/localhost\/taxonomy\/term\/37?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/canton"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/canton\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 37
+        }
+    ],
+    "uuid": [
+        {
+            "value": "7eb54de6-4f2c-471e-b84b-ac7a9c8ff729"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 37
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "canton"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2022-03-15T19:56:42+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Vaud",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/canton\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2022-03-15T19:56:42+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "metatag": [
+        {
+            "value": {
+                "title": "Vaud | Games of Switzerland"
+            }
+        }
+    ],
+    "metatag_normalized": [
+        {
+            "tag": "meta",
+            "attributes": {
+                "name": "title",
+                "content": "Vaud | Games of Switzerland"
+            },
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/7eb54de6-4f2c-471e-b84b-ac7a9c8ff729.json
@@ -107,5 +107,17 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_path": [
+        {
+            "value": "",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "vaud",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/7fd1c607-99c3-415c-92fc-b3033b2a7b90.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/7fd1c607-99c3-415c-92fc-b3033b2a7b90.json
@@ -107,5 +107,17 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_path": [
+        {
+            "value": "",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "geneva",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/7fd1c607-99c3-415c-92fc-b3033b2a7b90.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/7fd1c607-99c3-415c-92fc-b3033b2a7b90.json
@@ -1,0 +1,111 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/localhost\/taxonomy\/term\/38?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/canton"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/canton\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 38
+        }
+    ],
+    "uuid": [
+        {
+            "value": "7fd1c607-99c3-415c-92fc-b3033b2a7b90"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 38
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "canton"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2022-03-15T19:56:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Geneva",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/canton\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2022-03-15T19:56:59+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "metatag": [
+        {
+            "value": {
+                "title": "Geneva | Games of Switzerland"
+            }
+        }
+    ],
+    "metatag_normalized": [
+        {
+            "tag": "meta",
+            "attributes": {
+                "name": "title",
+                "content": "Geneva | Games of Switzerland"
+            },
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/b3165598-63fe-4717-a30e-11daf4389257.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/b3165598-63fe-4717-a30e-11daf4389257.json
@@ -1,0 +1,123 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/localhost\/locations\/lausanne?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 36
+        }
+    ],
+    "uuid": [
+        {
+            "value": "b3165598-63fe-4717-a30e-11daf4389257"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 36
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "location"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2022-03-15T19:56:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Lausanne",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2022-03-15T19:56:36+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "metatag": [
+        {
+            "value": {
+                "title": "Lausanne | Games of Switzerland"
+            }
+        }
+    ],
+    "metatag_normalized": [
+        {
+            "tag": "meta",
+            "attributes": {
+                "name": "title",
+                "content": "Lausanne | Games of Switzerland"
+            },
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/locations\/lausanne",
+            "pid": 24,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/locations\/lausanne",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "lausanne",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
@@ -256,6 +256,18 @@ class GameNodeIndex extends NodeIndexBase {
                 ],
               ],
             ],
+            'cantons' => [
+              'dynamic' => FALSE,
+              'type' => 'nested',
+              'properties' => [
+                'slug' => [
+                  'type' => 'keyword',
+                ],
+                'name' => [
+                  'type' => 'keyword',
+                ],
+              ],
+            ],
             'stores' => [
               'dynamic' => FALSE,
               'type' => 'nested',

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
@@ -202,6 +202,20 @@ class GameNormalizer extends ContentEntityNormalizer {
       $data['locations'] = $locations;
     }
 
+    // Handle cantons.
+    if (!$object->get('field_cantons')->isEmpty()) {
+      $cantons = [];
+
+      foreach ($object->field_cantons as $canton) {
+        $cantons[] = [
+          'name' => $canton->entity->get('name')->value,
+          'slug' => $canton->entity->get('field_slug')->value,
+        ];
+      }
+
+      $data['cantons'] = $cantons;
+    }
+
     return $data;
   }
 

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -48,6 +48,15 @@ class ElasticGamesResourceValidator extends BaseValidator {
   protected $raw;
 
   /**
+   * The game Cantons to filter by.
+   *
+   * This field uses the custom validation ::validateCantons.
+   *
+   * @var \Drupal\taxonomy\TermInterface[]|null
+   */
+  private $cantons;
+
+  /**
    * The game Genres to filter by.
    *
    * This field uses the custom validation ::validateGenres.
@@ -134,6 +143,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    * @Assert\Choice(choices={"", "apple_store", "steam", "amazon", "itchio", "facebook", "epic", "playstation", "xbox", "nintendo", "microsoft_store", "oculus", "google_play_store", "gog", "other"}, multiple=true)
    */
   private $stores;
+
+  /**
+   * Get the game Cantons to filter by.
+   *
+   * @return \Drupal\taxonomy\TermInterface[]|null
+   *   Cantons to filter by.
+   */
+  public function getCantons(): ?array {
+    return $this->cantons;
+  }
 
   /**
    * Get the game Genres to filter by.
@@ -243,6 +262,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function getStores(): ?array {
     return $this->stores;
+  }
+
+  /**
+   * Set the Cantons to filter by.
+   *
+   * @param \Drupal\taxonomy\TermInterface[] $cantons
+   *   Cantons to filter by.
+   */
+  public function setCantons(array $cantons): void {
+    $this->cantons = $cantons;
   }
 
   /**
@@ -356,6 +385,26 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
+   * Validates the Cantons parameter.
+   *
+   * Ensure the given taxonomy is a proper Cantons entity.
+   *
+   * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
+   *   The validation execution context.
+   * @param string $payload
+   *   The Payload.
+   *
+   * @Assert\Callback
+   */
+  public function validateCantons(ExecutionContextInterface $context, $payload): void {
+    if (isset($this->raw['cantons']) && !$this->cantons) {
+      $context->buildViolation(sprintf('At least one given Canton(s) has not been found.'))
+        ->atPath('cantons')
+        ->addViolation();
+    }
+  }
+
+  /**
    * Validates the Genres parameter.
    *
    * Ensure the given taxonomy is a proper Genres entity.
@@ -378,7 +427,7 @@ class ElasticGamesResourceValidator extends BaseValidator {
   /**
    * Validates the Locations parameter.
    *
-   * Ensure the given taxonomy is a proper Genres entity.
+   * Ensure the given taxonomy is a proper Locations entity.
    *
    * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
    *   The validation execution context.

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/resource/ElasticGamesResource.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/resource/ElasticGamesResource.php
@@ -137,6 +137,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addFullTextGameTitleCondition($search);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addFullTextGameTitleCondition($search);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addFullTextGameTitleCondition($search);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addFullTextGameTitleCondition($search);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addFullTextGameTitleCondition($search);
     }
 
@@ -151,6 +152,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addPlatformsFilter($platforms);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addPlatformsFilter($platforms);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addPlatformsFilter($platforms);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addPlatformsFilter($platforms);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addPlatformsFilter($platforms);
     }
 
@@ -165,6 +167,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addGenresFilter($genres);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addGenresFilter($genres);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addGenresFilter($genres);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addGenresFilter($genres);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addGenresFilter($genres);
     }
 
@@ -179,6 +182,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_genres']['filter']['bool']['should'][] = $this->addStoresFilter($stores);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addStoresFilter($stores);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addStoresFilter($stores);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addStoresFilter($stores);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addStoresFilter($stores);
     }
 
@@ -193,7 +197,23 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_genres']['filter']['bool']['should'][] = $this->addLocationsFilter($locations);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addLocationsFilter($locations);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addLocationsFilter($locations);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addLocationsFilter($locations);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addLocationsFilter($locations);
+    }
+
+    $cantons = $resource_validator->getCantons();
+
+    if ($cantons) {
+      // Filter the "hits" by given canton(s).
+      $es_query['body']['query']['bool']['filter']['bool']['must'][] = $this->addCantonsFilter($cantons);
+
+      // Filter the "aggregations" by given canton(s).
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_platforms']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_genres']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addCantonsFilter($cantons);
     }
 
     $release_year_range = $resource_validator->getReleaseYearRange();
@@ -208,6 +228,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addReleaseYearRangeFilter($release_year_range);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addReleaseYearRangeFilter($release_year_range);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addReleaseYearRangeFilter($release_year_range);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addReleaseYearRangeFilter($release_year_range);
     }
 
     $release_year = $resource_validator->getReleaseYear();
@@ -222,6 +243,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addReleaseYearFilter($release_year);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_states']['filter']['bool']['should'][] = $this->addReleaseYearFilter($release_year);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addReleaseYearFilter($release_year);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addReleaseYearFilter($release_year);
     }
 
     $states = $resource_validator->getStates();
@@ -235,6 +257,7 @@ class ElasticGamesResource extends ElasticResourceBase {
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_genres']['filter']['bool']['should'][] = $this->addStatesFilter($states);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_stores']['filter']['bool']['should'][] = $this->addStatesFilter($states);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_locations']['filter']['bool']['should'][] = $this->addStatesFilter($states);
+      $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_cantons']['filter']['bool']['should'][] = $this->addStatesFilter($states);
       $es_query['body']['aggregations']['aggs_all']['aggs']['all_filtered_release_years_histogram']['filter']['bool']['should'][] = $this->addStatesFilter($states);
     }
 
@@ -380,7 +403,58 @@ class ElasticGamesResource extends ElasticResourceBase {
       $resource_validator->setLocations($locations);
     }
 
+    // The canton(s) optional parameter.
+    if ($request->query->has('cantons')) {
+      /** @var \Drupal\taxonomy\TermInterface[] $cantons */
+      $cantons = [];
+
+      foreach ($request->query->get('cantons') as $slug) {
+        $canton = $this->termStorage->loadByProperties([
+          'vid' => 'canton',
+          'field_slug' => $slug,
+        ]);
+
+        if (!$canton) {
+          continue;
+        }
+
+        /** @var \Drupal\taxonomy\TermInterface $canton */
+        $canton = reset($canton);
+        $cantons[] = $canton;
+      }
+
+      $resource_validator->setCantons($cantons);
+    }
+
     return $resource_validator;
+  }
+
+  /**
+   * Add a condition to filter games by canton(s) slug.
+   *
+   * @param \Drupal\taxonomy\TermInterface[] $cantons
+   *   The collection of cantons to use for filtering.
+   *
+   * @return array
+   *   The Nested OR-Condition query to filter-out games by canton.
+   */
+  private function addCantonsFilter(array $cantons): array {
+    $structure = [
+      'nested' => [
+        'path' => 'cantons',
+        'query' => [
+          'bool' => [
+            'should' => [],
+          ],
+        ],
+      ],
+    ];
+
+    foreach ($cantons as $canton) {
+      $structure['nested']['query']['bool']['should'][] = ['term' => ['cantons.slug' => $canton->field_slug->value]];
+    }
+
+    return $structure;
   }
 
   /**
@@ -697,6 +771,7 @@ class ElasticGamesResource extends ElasticResourceBase {
                   ],
                 ],
               ],
+
               // Locations aggregations.
               'all_filtered_locations' => [
                 'filter' => [
@@ -734,6 +809,45 @@ class ElasticGamesResource extends ElasticResourceBase {
                   ],
                 ],
               ],
+
+              // Cantons aggregations.
+              'all_filtered_cantons' => [
+                'filter' => [
+                  'bool' => [
+                    // Where all the filter w/o a Score impact should be.
+                    'must' => [
+                      $this->addPublishedConditions(),
+                    ],
+                  ],
+                ],
+                'aggregations' => [
+                  'all_nested_cantons' => [
+                    'nested' => [
+                      'path' => 'cantons',
+                    ],
+                    'aggs' => [
+                      'cantons_name_keyword' => [
+                        'terms' => [
+                          'field' => 'cantons.slug',
+                          'min_doc_count' => 0,
+                          'size' => 50,
+                        ],
+                        'aggs' => [
+                          'cantons_facet_data' => [
+                            'top_hits' => [
+                              '_source' => [
+                                'cantons.name',
+                              ],
+                              'size' => 1,
+                            ],
+                          ],
+                        ],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+
               // Platforms aggregations.
               'all_filtered_platforms' => [
                 'filter' => [

--- a/web/modules/custom/gos_migrate/README.md
+++ b/web/modules/custom/gos_migrate/README.md
@@ -68,6 +68,15 @@ Before starting a migration,
   $ drush mim gos_games_update_website
   ```
 
+### Update Games with Canton(s) field
+
+1. Migrate all games' canton and attached them to proper games.
+
+  ```bash
+  $ drush mim gos_cantons
+  $ drush mim gos_games_update_canton
+  ```
+
 ### Update Elasticearch after updates
 
 1. Run a full Elasticsearch indexation process

--- a/web/modules/custom/gos_migrate/migrations/gos_games.gos_cantons.yml
+++ b/web/modules/custom/gos_migrate/migrations/gos_games.gos_cantons.yml
@@ -1,0 +1,75 @@
+id: gos_cantons
+label: Games of Switzerland - Cantons
+description: GOS - Migration of Cantons from CSV to Drupal 8
+migration_group: default
+
+source:
+  plugin: 'csv_cantons'
+  # Full path to the file.
+  path: '/source/games.csv'
+  # Column delimiter. Comma (,) by default.
+  delimiter: ','
+  # Field enclosure. Double quotation marks (") by default.
+  enclosure: '"'
+  # The row to be used as the CSV header (indexed from 0),
+  # or null if there is no header row.
+  header_offset: 0
+  # The column(s) to use as a key. Each column specified will
+  # create an index in the migration table and too many columns
+  # may throw an index size error.
+  ids:
+    - canton
+  # Here we identify the columns of interest in the source file.
+  # Each numeric key is the 0-based index of the column.
+  # For each column, the key below is the field name assigned to
+  # the data on import, to be used in field mappings below.
+  # The label value is a user-friendly string for display by the
+  # migration UI.
+  fields:
+    0:
+      name: game_title
+    1:
+      name: id
+    2:
+      name: platforms
+    3:
+      name: website
+    4:
+      name: studios
+    5:
+      name: people
+    6:
+      name: cantons
+    7:
+      name: locations
+    8:
+      name: publishers
+    9:
+      name: sponsors
+    10:
+      name: early_access_date
+    11:
+      name: release_date
+    12:
+      name: languages
+    13:
+      name: media
+    14:
+      name: genres
+
+process:
+  name:
+    -
+      plugin: skip_on_empty
+      method: row
+      source: canton
+    -
+      plugin: trim
+
+  uid:
+    plugin: default_value
+    default_value: 1
+
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: canton

--- a/web/modules/custom/gos_migrate/migrations/gos_games.update.canton.yml
+++ b/web/modules/custom/gos_migrate/migrations/gos_games.update.canton.yml
@@ -1,0 +1,141 @@
+id: gos_games_update_canton
+label: Games of Switzerland - Update Games - Canton field
+description: GOS - Migration of Game from CSV to Drupal 8
+migration_group: default
+
+source:
+  plugin: 'csv'
+  # Full path to the file.
+  path: '/source/games.csv'
+  # Column delimiter. Comma (,) by default.
+  delimiter: ','
+  # Field enclosure. Double quotation marks (") by default.
+  enclosure: '"'
+  # The row to be used as the CSV header (indexed from 0),
+  # or null if there is no header row.
+  header_offset: 0
+  # The column(s) to use as a key. Each column specified will
+  # create an index in the migration table and too many columns
+  # may throw an index size error.
+  ids:
+    - id
+  # Here we identify the columns of interest in the source file.
+  # Each numeric key is the 0-based index of the column.
+  # For each column, the key below is the field name assigned to
+  # the data on import, to be used in field mappings below.
+  # The label value is a user-friendly string for display by the
+  # migration UI.
+  fields:
+    0:
+      name: game_title
+    1:
+      name: id
+    2:
+      name: platforms
+    3:
+      name: website
+    4:
+      name: studios
+    5:
+      name: people
+    6:
+      name: cantons
+    7:
+      name: locations
+    8:
+      name: publishers
+    9:
+      name: sponsors
+    10:
+      name: early_access_date
+    11:
+      name: release_date
+    12:
+      name: languages
+    13:
+      name: media
+    14:
+      name: genres
+    15:
+      name: awards
+    16:
+      name: stores
+    17:
+      name: presskit
+    18:
+      name: articles
+    19:
+      name: twitter
+    20:
+      name: devlog
+    21:
+      name: source
+    22:
+      name: online_link
+    23:
+      name: page_link
+    24:
+      name: download_link
+    25:
+      name: video_link
+    26:
+      name: logo_link
+    27:
+      name: screenshot_link
+    28:
+      name: boxart_link
+    29:
+      name: description
+    30:
+      name: credits
+    31:
+      name: remarks
+    32:
+      name: state
+    33:
+      name: dataquality
+process:
+  nid:
+    -
+      plugin: skip_on_empty
+      method: row
+      source: id
+    -
+      plugin: migration_lookup
+      migration: gos_games
+    -
+      plugin: skip_on_empty
+      method: row
+
+  field_cantons:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: cantons
+    -
+      plugin: explode
+      delimiter: ","
+      limit: 10
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: trim
+            source: 'value'
+          -
+            plugin: migration_lookup
+            migration: gos_genres
+
+destination:
+  plugin: entity:node
+  default_bundle: game
+  overwrite_properties:
+    - field_cantons
+
+migration_dependencies:
+  required:
+    - default:gos_games
+    - default:gos_cantons

--- a/web/modules/custom/gos_migrate/src/Plugin/migrate/source/Cantons.php
+++ b/web/modules/custom/gos_migrate/src/Plugin/migrate/source/Cantons.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\gos_migrate\Plugin\migrate\source;
+
+/**
+ * {@inheritdoc}
+ *
+ * Extend the CSV migration tool to split multiple cantons on the same line
+ * into multiple rows for Drupal migration system.
+ *
+ * @MigrateSource(
+ *     id="csv_cantons",
+ *     source_module="gos_migrate"
+ * )
+ */
+class Cantons extends BaseRowExploded {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const ROW_EXPLODED_KEY = 'canton';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const ROW_ID_KEY = 'canton';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const SOURCE_KEY = 'cantons';
+
+}

--- a/web/modules/custom/gos_site/src/EventSubscriber/TaxonomyEntityReroute.php
+++ b/web/modules/custom/gos_site/src/EventSubscriber/TaxonomyEntityReroute.php
@@ -23,10 +23,30 @@ class TaxonomyEntityReroute extends BaseEntityReroute implements EventSubscriber
         ['isPlatform'],
         ['isLanguage'],
         ['isLocation'],
+        ['isCanton'],
         ['isPublisher'],
         ['isSponsor'],
       ],
     ];
+  }
+
+  /**
+   * Redirect Canton canonical to no-where.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   A response for a request.
+   *
+   * @psalm-suppress PossiblyInvalidArgument
+   */
+  public function isCanton(RequestEvent $event): void {
+    /** @var \Drupal\Core\Entity\ContentEntityBase $taxonomy_term */
+    $taxonomy_term = $this->routeMatch->getParameter('taxonomy_term');
+    $route_name = $this->routeMatch->getRouteName();
+
+    if ($route_name === 'entity.taxonomy_term.canonical' && $taxonomy_term->bundle() === 'canton') {
+      $response = $this->shutdownCanonicalTaxonomyTermAccess($event);
+      $event->setResponse($response);
+    }
   }
 
   /**

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -136,6 +136,18 @@
             "uniqueItems": true
           },
           {
+            "name": "cantons[]",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "description": "Collection of cantons slug. Items are matched using an Inner OR condition.",
+            "items": {
+              "type": "string"
+            },
+            "example": "vaud",
+            "uniqueItems": true
+          },
+          {
             "name": "stores[]",
             "in": "query",
             "required": false,


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.

### 🗃️ Issues
This pull request is related to :
- close Games-of-Switzerland/swissgamesgarden#51

### 🚧 What has been done
- new Taxonomy Canton
- Pathauto for Canton
- Json:API exposition of Canton
- 2 new default content for Canton
- Cantons field in Games
- Behat coverage of vocabulary Canton
- Add migrations of Canton
- Add Cantons' games to Elasticsearch
- Allow filtering by Cantons slug
- Behat coverage of ES filtering by Canton(s)

### 🔢 To Review
Steps to review the PR:

1. `drush cim -y && drush cr`
2. Games should be able to have Canton(s)
3. You should be able to create Canton as Taxonomy
3. Created Canton will automatically have a slug if not defined during CRUD.
3. Canton should be migrated on `drush mim gos_cantons`
3. Canton should be lookuped on `drush mim gos_games_update_canton`
