### PR TITLE
update module drupal/simple_sitemap (3.11.0 => 4.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- update module drupal/simple_sitemap (3.11.0 => 4.1.2)
 
 ## [0.5.0] - 2022-09-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ As we are working in a decoupled architecture, we need to set the Website URL.
  *
  * @var string
  */
-$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
+$config['frontend']['base_url'] = 'https://swissgames.garden';
 ```
 
 #### Sitemap
@@ -94,7 +94,7 @@ The base URL of sitemap links can be overridden using the following settings.
  *
  * @var string
  */
-$config['simple_sitemap.settings']['base_url'] = 'https://api-gos.museebolo.ch';
+$config['simple_sitemap.settings']['base_url'] = 'https://api.swissgames.garden';
 ```
 
 #### Symfony Mailer, Sendmail & Mailcatcher

--- a/behat/Features/redirects/game.feature
+++ b/behat/Features/redirects/game.feature
@@ -4,5 +4,5 @@ Feature: Game node redirection
   Scenario: Accessing a node Game page should permanently redirect you to the Next/React app.
     Given I am on "/node/12"
     Then the response status code should be 301
-    Then I should be redirected to "https://gos.museebolo.ch/games/farming-simulator-19"
+    Then I should be redirected to "https://swissgames.garden/games/farming-simulator-19"
 

--- a/behat/Features/redirects/people.feature
+++ b/behat/Features/redirects/people.feature
@@ -4,5 +4,5 @@ Feature: People node redirection
   Scenario: Accessing a node People page should permanently redirect you to the Next/React app.
     Given I am on "/node/13"
     Then the response status code should be 301
-    Then I should be redirected to "https://gos.museebolo.ch/people/jeremy-wuthrer-cuany"
+    Then I should be redirected to "https://swissgames.garden/people/jeremy-wuthrer-cuany"
 

--- a/behat/Features/redirects/studio.feature
+++ b/behat/Features/redirects/studio.feature
@@ -4,5 +4,5 @@ Feature: Studio node redirection
   Scenario: Accessing a node Studio page should permanently redirect you to the Next/React app.
     Given I am on "/node/15"
     Then the response status code should be 301
-    Then I should be redirected to "https://gos.museebolo.ch/studios/giants-software"
+    Then I should be redirected to "https://swissgames.garden/studios/giants-software"
 

--- a/behat/Features/sitemap.feature
+++ b/behat/Features/sitemap.feature
@@ -7,11 +7,38 @@ Feature: Sitemap
 
   Scenario: The Sitemap contain the proper pages and not everything
     Given the sitemap "/sitemap.xml"
-    Then the sitemap should have 9 children
+    Then the sitemap should have 10 children
 
   Scenario: The Sitemap contain absolute URL pointing to React/Next App.
     Given I am on "/sitemap.xml"
-    Then the XML element "//url[1]/loc" should contain "https://gos.museebolo.ch/games/dont-kill-her"
-    Then the XML element "//url[5]/loc" should contain "https://gos.museebolo.ch/pages/about-us"
-    Then the XML element "//url[6]/loc" should contain "https://gos.museebolo.ch/people/jeremy-wuthrer-cuany"
-    Then the XML element "//url[9]/loc" should contain "https://gos.museebolo.ch/studios/giants-software"
+    Then the response should contain "https://swissgames.garden/"
+
+  Scenario: The Sitemap contains Games with adapted scoring and change frequency.
+    Given I am on "/sitemap.xml"
+    Then the XML element "//url[1]/loc" should contain "https://swissgames.garden/games/dont-kill-her"
+    Then the XML element "//url[1]/changefreq" should contain "monthly"
+    Then the XML element "//url[1]/priority" should contain "1.0"
+
+  Scenario: The Sitemap contains Basic Pages with adapted scoring and change frequency.
+    Given I am on "/sitemap.xml"
+    Then the XML element "//url[5]/loc" should contain "https://swissgames.garden/pages/about-us"
+    Then the XML element "//url[5]/changefreq" should contain "yearly"
+    Then the XML element "//url[5]/priority" should contain "0.7"
+
+  Scenario: The Sitemap contains People with adapted scoring and change frequency.
+    Given I am on "/sitemap.xml"
+    Then the XML element "//url[6]/loc" should contain "https://swissgames.garden/people/jeremy-wuthrer-cuany"
+    Then the XML element "//url[6]/changefreq" should contain "monthly"
+    Then the XML element "//url[6]/priority" should contain "0.5"
+
+  Scenario: The Sitemap contains Studios with adapted scoring and change frequency.
+    Given I am on "/sitemap.xml"
+    Then the XML element "//url[9]/loc" should contain "https://swissgames.garden/studios/giants-software"
+    Then the XML element "//url[9]/changefreq" should contain "monthly"
+    Then the XML element "//url[9]/priority" should contain "0.5"
+
+  Scenario: The Sitemap contains the homepage with adapted scoring and change frequency.
+    Given I am on "/sitemap.xml"
+    Then the XML element "//url[10]/loc" should contain "https://swissgames.garden/"
+    Then the XML element "//url[10]/changefreq" should contain "always"
+    Then the XML element "//url[10]/priority" should contain "1.0"

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/new_relic_rpm": "^2.1",
         "drupal/pathauto": "^1.6",
         "drupal/restui": "^1.18",
-        "drupal/simple_sitemap": "^3.7",
+        "drupal/simple_sitemap": "^4.1",
         "drupal/symfony_mailer": "^1.0@alpha",
         "drupal/views_ef_fieldset": "^1.4",
         "drupal/webp": "^1.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1e8196cc563b7ab4c846b5f7925387a",
+    "content-hash": "46d927b77e9657d33c2a7428bdfce894",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3252,27 +3252,27 @@
         },
         {
             "name": "drupal/simple_sitemap",
-            "version": "3.11.0",
+            "version": "4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_sitemap.git",
-                "reference": "8.x-3.11"
+                "reference": "4.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.11.zip",
-                "reference": "8.x-3.11",
-                "shasum": "5fdd4ed5af5e37e3c707e401d094a179f52e7711"
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.2.zip",
+                "reference": "4.1.2",
+                "shasum": "0b695684d0a6dd2a6162051aac7dab4852d72214"
             },
             "require": {
-                "drupal/core": "^8 || ^9",
+                "drupal/core": "^9.3 || ^10",
                 "ext-xmlwriter": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.11",
-                    "datestamp": "1658781789",
+                    "version": "4.1.2",
+                    "datestamp": "1655334556",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3304,8 +3304,7 @@
             "homepage": "https://drupal.org/project/simple_sitemap",
             "support": {
                 "source": "https://cgit.drupalcode.org/simple_sitemap",
-                "issues": "https://drupal.org/project/issues/simple_sitemap",
-                "irc": "irc://irc.freenode.org/drupal-contribute"
+                "issues": "https://drupal.org/project/issues/simple_sitemap"
             }
         },
         {

--- a/config/d8/sync/simple_sitemap.bundle_settings.default.node.game.yml
+++ b/config/d8/sync/simple_sitemap.bundle_settings.default.node.game.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.8'
-changefreq: weekly
+priority: '1.0'
+changefreq: monthly
 include_images: false

--- a/config/d8/sync/simple_sitemap.bundle_settings.default.node.page.yml
+++ b/config/d8/sync/simple_sitemap.bundle_settings.default.node.page.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '1.0'
-changefreq: weekly
+priority: '0.7'
+changefreq: yearly
 include_images: false

--- a/config/d8/sync/simple_sitemap.bundle_settings.default.node.people.yml
+++ b/config/d8/sync/simple_sitemap.bundle_settings.default.node.people.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.3'
+priority: '0.5'
 changefreq: monthly
 include_images: false

--- a/config/d8/sync/simple_sitemap.bundle_settings.default.node.studio.yml
+++ b/config/d8/sync/simple_sitemap.bundle_settings.default.node.studio.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.3'
+priority: '0.5'
 changefreq: monthly
 include_images: false

--- a/config/d8/sync/simple_sitemap.custom_links.default.yml
+++ b/config/d8/sync/simple_sitemap.custom_links.default.yml
@@ -1,7 +1,5 @@
-_core:
-  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw
 links:
   -
     path: /
     priority: '1.0'
-    changefreq: daily
+    changefreq: always

--- a/config/d8/sync/simple_sitemap.settings.yml
+++ b/config/d8/sync/simple_sitemap.settings.yml
@@ -8,7 +8,7 @@ remove_duplicates: true
 skip_untranslated: true
 disable_language_hreflang: false
 xsl: true
-base_url: ''
+base_url: 'https://swissgames.garden'
 default_variant: default
 custom_links_include_images: false
 excluded_languages: {  }

--- a/config/d8/sync/simple_sitemap.sitemap.default.yml
+++ b/config/d8/sync/simple_sitemap.sitemap.default.yml
@@ -6,6 +6,6 @@ dependencies:
     - simple_sitemap.type.default_hreflang
 id: default
 label: Default
-description: null
+description: ''
 type: default_hreflang
 weight: 0

--- a/config/d8/sync/simple_sitemap.sitemap.default.yml
+++ b/config/d8/sync/simple_sitemap.sitemap.default.yml
@@ -1,0 +1,11 @@
+uuid: 51e1e671-f6b9-4a12-b2d7-720de95706a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - simple_sitemap.type.default_hreflang
+id: default
+label: Default
+description: null
+type: default_hreflang
+weight: 0

--- a/config/d8/sync/simple_sitemap.sitemap.index.yml
+++ b/config/d8/sync/simple_sitemap.sitemap.index.yml
@@ -1,0 +1,11 @@
+uuid: e0c0ba8c-e6e8-484e-8e89-756e07563dc9
+langcode: en
+status: false
+dependencies:
+  config:
+    - simple_sitemap.type.index
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index listing all other sitemaps - useful if there are at least two other sitemaps. In most cases this sitemap should be last in the generation queue and set as the default sitemap.'
+type: index
+weight: 1000

--- a/config/d8/sync/simple_sitemap.type.default_hreflang.yml
+++ b/config/d8/sync/simple_sitemap.type.default_hreflang.yml
@@ -1,0 +1,13 @@
+uuid: 32e1fdbe-0b2e-45ab-ad88-bacbc40b644c
+langcode: en
+status: true
+dependencies: {  }
+id: default_hreflang
+label: 'Default hreflang'
+description: 'The default hreflang sitemap type.'
+sitemap_generator: default
+url_generators:
+  - custom
+  - entity
+  - entity_menu_link_content
+  - arbitrary

--- a/config/d8/sync/simple_sitemap.type.default_hreflang.yml
+++ b/config/d8/sync/simple_sitemap.type.default_hreflang.yml
@@ -7,7 +7,5 @@ label: 'Default hreflang'
 description: 'The default hreflang sitemap type.'
 sitemap_generator: default
 url_generators:
-  - custom
-  - entity
-  - entity_menu_link_content
-  - arbitrary
+  nextjs: nextjs
+  custom: custom

--- a/config/d8/sync/simple_sitemap.type.index.yml
+++ b/config/d8/sync/simple_sitemap.type.index.yml
@@ -1,0 +1,10 @@
+uuid: f450ffa3-95cc-4cb8-ab2e-e53ab280b409
+langcode: en
+status: true
+dependencies: {  }
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index sitemap type. A sitemap of this type lists sitemaps of all other types.'
+sitemap_generator: index
+url_generators:
+  - index

--- a/config/d8/sync/simple_sitemap.variants.default_hreflang.yml
+++ b/config/d8/sync/simple_sitemap.variants.default_hreflang.yml
@@ -1,6 +1,0 @@
-_core:
-  default_config_hash: nQAXscP-SDpsmqHlQ6u0iBvcuJPrAikb09c3cP2_n0k
-variants:
-  default:
-    label: Default
-    weight: 0

--- a/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
+++ b/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
@@ -72,12 +72,14 @@ class UrlBuilderNextJs {
     /** @var string $bundle */
     $bundle = $entity->bundle();
 
-    if (!isset(self::NEXTJS_URLS_PREFIX[$bundle])) {
-      throw new \InvalidArgumentException(sprintf('Bundle %s is not valid.', $bundle));
-    }
-
     if (!$langcode) {
       $langcode = $entity->language()->getId();
+    }
+
+    // To prevent a missing key error, we prevent the rest.
+    // If the bundle type is not specified.
+    if (!\array_key_exists($bundle, self::NEXTJS_URLS_PREFIX)) {
+      throw new \InvalidArgumentException(sprintf('Bundle type [%s] is not present in the URLS prefixes', $bundle));
     }
 
     // To prevent a missing key error, throw an error if lang is not found.

--- a/web/sites/default/settings.development.php
+++ b/web/sites/default/settings.development.php
@@ -46,14 +46,14 @@ $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = '9200
  *
  * This value should not contain a leading slash (/).
  */
-$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
+$config['frontend']['base_url'] = 'https://swissgames.garden';
 
 /**
  * The base URL of sitemap links can be overridden here.
  *
  * @var string
  */
-$config['simple_sitemap.settings']['base_url'] = 'http://api.gos.test';
+$config['simple_sitemap.settings']['base_url'] = 'https://swissgames.garden';
 
 /**
  * The Symfony Mailer transporter.

--- a/web/sites/default/settings.test.php
+++ b/web/sites/default/settings.test.php
@@ -43,14 +43,14 @@ $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = 'elas
  *
  * This value should not contain a leading slash (/).
  */
-$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
+$config['frontend']['base_url'] = 'https://swissgames.garden';
 
 /**
  * The base URL of sitemap links can be overridden here.
  *
  * @var string
  */
-$config['simple_sitemap.settings']['base_url'] = 'https://gos.museebolo.ch';
+$config['simple_sitemap.settings']['base_url'] = 'https://swissgames.garden';
 
 /**
  * The Symfony Mailer transporter.


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.

```bash
composer require drupal/simple_sitemap:^4.1
```

```bash
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading drupal/simple_sitemap (3.11.0 => 4.1.2)
```

```bash
 ---------------- ----------- --------------- ---------------------------------
  Module           Update ID   Type            Description
 ---------------- ----------- --------------- ---------------------------------
  simple_sitemap   8401        hook_update_n   8401 - Change the
                                               simple_sitemap ID column to
                                               serial.
  simple_sitemap   8402        hook_update_n   8402 - Install new
                                               simple_sitemap_type and
                                               simple_sitemap configuration
                                               entities.
  simple_sitemap   8403        hook_update_n   8403 - Migrate the
                                               default_hreflang sitemap type
                                               and its variants to new
                                               configuration entities.
  simple_sitemap   8404        hook_update_n   8404 - Add dependencies to
                                               sitemap entities.
  simple_sitemap   8405        hook_update_n   8405 - Create the index sitemap
                                               type.
  simple_sitemap   8406        hook_update_n   8406 - Create the index
                                               sitemap.
 ---------------- ----------- --------------- ---------------------------------
```