### PR TITLE
fix field_cantons json:api public name to be 'cantons'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix field_cantons json:api public name to be 'cantons'
 
 ## [0.5.2] - 2022-11-07
 ### Security

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
@@ -165,6 +165,12 @@ resourceFields:
     publicName: awards
     enhancer:
       id: ''
+  field_cantons:
+    disabled: false
+    fieldName: field_cantons
+    publicName: cantons
+    enhancer:
+      id: ''
   field_completeness:
     disabled: false
     fieldName: field_completeness


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.
fix field_cantons json:api public name to be 'cantons'