### PR TITLE
fix NextJS redirection failed when entity start with langcode. Eg /en…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - apply type-hinting to const
 - uninstall deprecated & unused module CKEditor 4
 
+### Fixed
+- fix NextJS redirection failed when entity start with langcode. Eg /enlight of /frenchy ... that match /en or /fr
+
 ## [1.4.0] - 2025-05-29
 ### Security
 - update drupal/core-dev (10.4.1 => 10.4.7)

--- a/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
+++ b/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
@@ -95,7 +95,7 @@ class UrlBuilderNextJs {
     /** @var string $slug */
     $slug = $translation->toUrl('canonical')->toString();
     // Remove the langcode part as will be added manually later in the process.
-    $slug = str_replace("/{$langcode}", '', $slug);
+    $slug = str_replace("/{$langcode}/", '/', $slug);
 
     // Build the complete destination path starting with the base URL.
     $base_url = $this->configFactory->get('frontend')->get('base_url');


### PR DESCRIPTION
### 💬 Describe the pull request
fix NextJS redirection failed when entity start with langcode. 

Eg /enlightware of /frenchy ... that match /en or /fr.

### 🔢 To Review
Steps to review the PR:
1. Create a studio and name it "enlightware"
2. The redirect link must works with `https://api.swissgames.garden/studios/enlightware` thant then redirect on `https://swissgames.garden/studio/enlightware`
3. When it does not works it redirected on `https://swissgames.garden/studioslightware`