### PR TITLE
add & setup module Save & Edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - apply type-hinting to const
 - uninstall deprecated & unused module CKEditor 4
 
+### Added
+- add & setup module Save & Edit
+
 ## [1.4.0] - 2025-05-29
 ### Security
 - update drupal/core-dev (10.4.1 => 10.4.7)

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/new_relic_rpm": "^2.1",
         "drupal/pathauto": "^1.6",
         "drupal/restui": "^1.18",
+        "drupal/save_edit": "^1.8",
         "drupal/simple_sitemap": "^4.1",
         "drupal/symfony_mailer": "^1.0@alpha",
         "drupal/views_ef_fieldset": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb1788f2276529bb332c6f2016e7ccd0",
+    "content-hash": "a4465bc49fee652c209dae39905f593e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3289,6 +3289,66 @@
             "homepage": "https://www.drupal.org/project/restui",
             "support": {
                 "source": "https://git.drupalcode.org/project/restui"
+            }
+        },
+        {
+            "name": "drupal/save_edit",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/save_edit.git",
+                "reference": "8.x-1.8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/save_edit-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "9562c97eaaea350fe8db4ec69291533ebd65be90"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.8",
+                    "datestamp": "1721432174",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "caesius",
+                    "homepage": "https://www.drupal.org/user/1807592"
+                },
+                {
+                    "name": "himerus",
+                    "homepage": "https://www.drupal.org/user/159141"
+                },
+                {
+                    "name": "NitinSP",
+                    "homepage": "https://www.drupal.org/user/2198938"
+                },
+                {
+                    "name": "q__nt_n",
+                    "homepage": "https://www.drupal.org/user/3512064"
+                }
+            ],
+            "description": "Gives a 'Save & Edit' button on node pages.",
+            "homepage": "https://www.drupal.org/project/save_edit",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/save_edit",
+                "issues": "http://drupal.org/project/issues/save_edit"
             }
         },
         {
@@ -16113,7 +16173,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-exif": "*"
     },
     "platform-dev": [],

--- a/config/d8/sync/core.extension.yml
+++ b/config/d8/sync/core.extension.yml
@@ -64,6 +64,7 @@ module:
   phpass: 0
   rest: 0
   restui: 0
+  save_edit: 0
   serialization: 0
   simple_sitemap: 0
   symfony_mailer: 0

--- a/config/d8/sync/save_edit.settings.yml
+++ b/config/d8/sync/save_edit.settings.yml
@@ -1,0 +1,17 @@
+_core:
+  default_config_hash: BbDroIEr8r2Tl5vtErNAIWGeDf5UKZwN9Lt82Fl9iiE
+button_value: 'Save & Edit'
+button_weight: '-1'
+gin_primary: true
+unpublish: false
+unpublish_new_only: false
+hide_default_save: false
+hide_default_publish: false
+hide_default_preview: true
+hide_default_delete: false
+enable_node_types_automatically: false
+node_types:
+  game: game
+  page: page
+  people: people
+  studio: studio


### PR DESCRIPTION
### 💬 Describe the pull request
add & setup module Save & Edit

### 🔢 To Review
Steps to review the PR:
1. Newer button on node creation/edition that allows to stay on Drupal upon saving

### 📸 Screenshots

![CleanShot 2025-06-19 at 16 35 57](https://github.com/user-attachments/assets/ec0ea374-29f3-4d59-bf03-b5aad5da46f3)